### PR TITLE
Branch kit added sortbypref and other

### DIFF
--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.cpp
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.cpp
@@ -1,4 +1,4 @@
-//v0.2.4
+//v0.2.5
 #include <cassert>
 #include <cstdlib>
 #include "member.h"

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.cpp
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.cpp
@@ -1,4 +1,4 @@
-//v0.2.3
+//v0.2.4
 #include <cassert>
 #include <cstdlib>
 #include "member.h"
@@ -170,4 +170,17 @@ void wholesalegroup::Member::calcExpDate(const string &joinDate) {
 
 wholesalegroup::Member::~Member() {
     delete[] this->purchases;
+}
+
+void wholesalegroup::Member::operator=(Member & other)                  // Added by kit 4/6/2017
+{
+	info = other.GetInfo();
+	allocated = other.PurchaseLen();
+	purchases = other.PurchaseHistory();
+	this->size = other.PurchaseLen();
+}
+
+wholesalegroup::Purchase *& wholesalegroup::Member::PurchaseHistory()   // Added by Kit 4/6/2017
+{
+	return purchases;
 }

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
@@ -63,6 +63,9 @@ public:
     inline void SetType(Membership new_type) { this->info.type = new_type;}
     inline void ChangeName(const std::string &new_name) { this->info.name = new_name;}
     inline void setExpDate(const std::string &expDate) {this->info.expDate = expDate;} //expDate: MM/DD/YYYY
+    
+    void operator =(Member &other); //Added by Kit 4/6/2017
+    Purchase*& PurchaseHistory();   //Added by Kit 4/6/2017
 
     ~Member();
 private:

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
@@ -1,4 +1,4 @@
-//v0.2.3
+//v0.2.4
 //UPDATE NOTES:
 //No real changes, typo on line 139 was fixed new_Price -> new_price (lowercase)
 

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/member.h
@@ -1,4 +1,4 @@
-//v0.2.4
+//v0.2.5
 //UPDATE NOTES:
 //No real changes, typo on line 139 was fixed new_Price -> new_price (lowercase)
 

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/sequence.cpp
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/sequence.cpp
@@ -1,4 +1,4 @@
-// version 0.1.3
+// version 0.1.5
 #include "sequence.h"
 #include <iostream>
 #include <algorithm>                   // used for copy. Again should we right our own?
@@ -179,7 +179,7 @@ void Sequence::add_member(valPtr &entry)
         }
     data[used] = entry;
     used++;
-    sort();
+    // sort();                                      // Kit : "I had to remove this. Will explain eslewhere."
 }
 
 void Sequence::remove_member(int id)
@@ -289,3 +289,37 @@ int Sequence::find_user(string name)
     return -1;
 }
 ///**END OF NEW FUNCTIONS IN THIS VERSION
+
+///**NewFunction from version 0.1.5
+Sequence& Sequence::sortByPref()
+{
+	Sequence* prefSorted = new Sequence;
+
+	prefSorted->current_index = this->current_index;
+	prefSorted->capacity = this->capacity;
+
+	start();
+	// Fill preferred
+	while (this->is_item())
+	{
+		wholesalegroup::Member* temp = current();
+		if (current()->GetType() == wholesalegroup::preferred)
+		{
+			prefSorted->add_member(temp);
+		}
+		advance();
+	}
+	start();
+	// Fill the basic
+	while (this->is_item())
+	{
+		wholesalegroup::Member* temp = current();
+		if (current()->GetType() == wholesalegroup::basic)
+		{
+			prefSorted->add_member(temp);
+		}
+		advance();
+	}
+	return *prefSorted;
+}
+//** End of new function from version 0.1.5

--- a/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/sequence.h
+++ b/Super Warehouse Store Group Project/Super-Warehouse-Store-Group-Project/sequence.h
@@ -1,4 +1,4 @@
-// version 0.1.3
+// version 0.1.5
 // SEQUENCE CLASS FOR OUR SUPER WAREHOUSE PROJECT
 
 //UPDATE NOTES:
@@ -64,6 +64,9 @@ public:
 
     ///***END OF NEW FUNCTIONS IN THIS VERSION
 
+    //**KITS SORT PREFERRED
+    Sequence& sortByPref();
+    // ** END
 private:
     size_type capacity;
     valPtr* data;


### PR DESCRIPTION
member vesion 0.2.5
sequence version 0.1.5
I added the sortbypref to the sequence class. 

In the process, I had to add an =operator overload to the member class and a purchases history(which returns a purchase pointer) to the member class.

I also had to change the sequence class to have so that sort was NO LONGER AUTOMATIC on addmembers. This is because, I had to use addMembers in my function, and it would sort the array during the sort pref meaning no change. Therefore, you guys have to call sort if you want to have a consisntently sorted array.